### PR TITLE
Add Numblr to Listening section — free number listening practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
   
 - [Playphrase](https://www.playphrase.me/#/search) - a free-to-use Web app that lets you search for specific phrases, quotes, or dialogues extracted from movies.
 
+- [Numblr](https://numblr.io) - free app dedicated to English number listening — practice hearing dates, times, phone numbers, and money amounts in real-world contexts and type what you hear.
+
 ## 🔸 Vocabulary
 
 - [Play Scrabble](https://playscrabble.com/) - play Scrabble on-line


### PR DESCRIPTION
Hi! Really love the variety of resources in this list, it covers so many different aspects of learning English.

I'd like to suggest adding **Numblr** (https://numblr.io), a free web app for English number listening practice. Users hear numbers in real-world contexts (dates, times, phone numbers, money amounts) and type what they hear.

Number recognition is a specific listening skill that tends to get overlooked in general listening practice, but it comes up constantly in everyday life and in exams like IELTS and TOEFL. I thought it could be a nice addition to the Listening and Reading section alongside the other listening tools. It's free with no account needed to get started.

Happy to tweak the description or placement if you have a better fit in mind!